### PR TITLE
Dialer: Fix compilation warnings

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -31,8 +31,6 @@ src_dirs += \
     $(phone_common_dir)/src-N
 
 LOCAL_SRC_FILES := $(call all-java-files-under, $(src_dirs)) $(call all-Iaidl-files-under, $(src_dirs))
-LOCAL_SRC_FILES += src/org/codeaurora/presenceserv/IPresenceService.aidl \
-                   src/org/codeaurora/presenceserv/IPresenceServiceCB.aidl
 LOCAL_RESOURCE_DIR := $(addprefix $(LOCAL_PATH)/, $(res_dirs)) \
     $(support_library_root_dir)/v7/cardview/res \
     $(support_library_root_dir)/v7/recyclerview/res \


### PR DESCRIPTION
* Commit 8cb34a6a2c05e7b8b354f64442bb0b033b4a544c added
  these 2 files in LOCAL_SRC_FILES, however they are
  now included by the rule right above which was
  introduced in 3e5694aab51d48497a79be35159701ff8db8fa77,
  so the build system emits warnings.

Change-Id: Ic2f89789807af842e15c36678eb64d4d095d8ad3